### PR TITLE
Fix/platform io compiles

### DIFF
--- a/Software/src/Animations.cpp
+++ b/Software/src/Animations.cpp
@@ -5,7 +5,6 @@ void animation_day_gradient();
 void animation_hour_gradient();
 void animation_min_gradient();
 void animation_const();
-//double map_double(double x2, double x1, double x3, double y1, double y3);
 double map_double(double, double, double, double, double);
 
 void handle_animation(int animation_func) {

--- a/Software/src/Animations.h
+++ b/Software/src/Animations.h
@@ -1,0 +1,11 @@
+#include "Common.h"
+
+void animation_cycle();
+void animation_day_gradient();
+void animation_hour_gradient();
+void animation_min_gradient();
+void animation_const();
+
+double map_double(double, double, double, double, double);
+
+void handle_animation(int animation_func);

--- a/Software/src/Animations.h
+++ b/Software/src/Animations.h
@@ -1,11 +1,3 @@
 #include "Common.h"
 
-void animation_cycle();
-void animation_day_gradient();
-void animation_hour_gradient();
-void animation_min_gradient();
-void animation_const();
-
-double map_double(double, double, double, double, double);
-
 void handle_animation(int animation_func);

--- a/Software/src/Segments_Hour.h
+++ b/Software/src/Segments_Hour.h
@@ -3,14 +3,3 @@
 #include "Common.h"
 
 void set_hr(int hour_number);
-void set_hr_off(int array_start);
-void set_hr_0(int array_start);
-void set_hr_1(int array_start);
-void set_hr_2(int array_start);
-void set_hr_3(int array_start);
-void set_hr_4(int array_start);
-void set_hr_5(int array_start);
-void set_hr_6(int array_start);
-void set_hr_7(int array_start);
-void set_hr_8(int array_start);
-void set_hr_9(int array_start);

--- a/Software/src/Segments_Hour.h
+++ b/Software/src/Segments_Hour.h
@@ -1,0 +1,16 @@
+#include <FastLED.h>
+
+#include "Common.h"
+
+void set_hr(int hour_number);
+void set_hr_off(int array_start);
+void set_hr_0(int array_start);
+void set_hr_1(int array_start);
+void set_hr_2(int array_start);
+void set_hr_3(int array_start);
+void set_hr_4(int array_start);
+void set_hr_5(int array_start);
+void set_hr_6(int array_start);
+void set_hr_7(int array_start);
+void set_hr_8(int array_start);
+void set_hr_9(int array_start);

--- a/Software/src/Segments_Minute.h
+++ b/Software/src/Segments_Minute.h
@@ -3,13 +3,3 @@
 #include "Common.h"
 
 void set_mn(int min_number);
-void set_mn_0(int array_start);
-void set_mn_1(int array_start);
-void set_mn_2(int array_start);
-void set_mn_3(int array_start);
-void set_mn_4(int array_start);
-void set_mn_5(int array_start);
-void set_mn_6(int array_start);
-void set_mn_7(int array_start);
-void set_mn_8(int array_start);
-void set_mn_9(int array_start);

--- a/Software/src/Segments_Minute.h
+++ b/Software/src/Segments_Minute.h
@@ -1,0 +1,15 @@
+#include <FastLED.h>
+
+#include "Common.h"
+
+void set_mn(int min_number);
+void set_mn_0(int array_start);
+void set_mn_1(int array_start);
+void set_mn_2(int array_start);
+void set_mn_3(int array_start);
+void set_mn_4(int array_start);
+void set_mn_5(int array_start);
+void set_mn_6(int array_start);
+void set_mn_7(int array_start);
+void set_mn_8(int array_start);
+void set_mn_9(int array_start);

--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -84,8 +84,8 @@ bool dst_state = 1;
 WiFiUDP ntpUDP;
 NTPClient timeClient(ntpUDP, "north-america.pool.ntp.org", 0, NTP_UPDATE_INT);
 
-//CRGB leds_hr[NUM_LEDS_HR];
-//CRGB leds_mn[NUM_LEDS_MN];
+CRGB leds_hr[NUM_LEDS_HR];
+CRGB leds_mn[NUM_LEDS_MN];
 
 DEFINE_GRADIENT_PALETTE( MyRainbow ) { // row: palette index, R, G, B
       0, 255,   0,   0,    //    Red

--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -18,9 +18,9 @@
 #include <WiFiManager.h>
 
 #include "Common.h"
-#include "Segments_Hour.cpp"
-#include "Segments_Minute.cpp"
-#include "Animations.cpp"
+#include "Segments_Hour.h"
+#include "Segments_Minute.h"
+#include "Animations.h"
 
 // FastLED Variables
 #define NUM_LEDS_HR                14


### PR DESCRIPTION
builds on #4 

resolves an undefined error:
```
~/.platformio/packages/toolchain-xtensa/bin/../lib/gcc/xtensa-lx106-elf/4.8.2/../../../../xtensa-lx106-elf/bin/ld: .pio/build/nodemcuv2/src/Segments_Hour.cpp.o:(.text._Z10set_hr_offi+0x0): undefined reference to `leds_hr'
~/.platformio/packages/toolchain-xtensa/bin/../lib/gcc/xtensa-lx106-elf/4.8.2/../../../../xtensa-lx106-elf/bin/ld: .pio/build/nodemcuv2/src/Segments_Minute.cpp.o:(.text._Z8set_mn_0i+0x0): undefined reference to `leds_mn'
```

which was the last issue, now finishes compiling:
```
Retrieving maximum program size .pio/build/nodemcuv2/firmware.elf
Checking size .pio/build/nodemcuv2/firmware.elf
Memory Usage -> http://bit.ly/pio-memory-usage
DATA:    [====      ]  39.3% (used 32172 bytes from 81920 bytes)
PROGRAM: [===       ]  30.7% (used 320644 bytes from 1044464 bytes)
=====[SUCCESS]=====
```